### PR TITLE
Various improvements

### DIFF
--- a/samples/ModernApplicationFramework.Extended.Demo/DemoBootstrapper.cs
+++ b/samples/ModernApplicationFramework.Extended.Demo/DemoBootstrapper.cs
@@ -2,8 +2,13 @@
 
 namespace ModernApplicationFramework.Extended.Demo
 {
-    public class DemoBootstrapper : ExtendedBootstrapper
+    public sealed class DemoBootstrapper : ExtendedBootstrapper
     {
         protected override IExtendedEnvironmentVariables EnvironmentVariables => new DemoEnvironmentVariables();
+
+        public DemoBootstrapper()
+        {
+            Initialize();
+        }
     }
 }

--- a/samples/ModernApplicationFramework.Extended.DemoMin/DemoBootstrapper.cs
+++ b/samples/ModernApplicationFramework.Extended.DemoMin/DemoBootstrapper.cs
@@ -2,8 +2,13 @@
 
 namespace ModernApplicationFramework.Extended.DemoMin
 {
-    public class DemoBootstrapper : ExtendedBootstrapper
+    public sealed class DemoBootstrapper : ExtendedBootstrapper
     {
         protected override IExtendedEnvironmentVariables EnvironmentVariables => new DemoEnvironmentVariables();
+
+        public DemoBootstrapper()
+        {
+            Initialize();
+        }
     }
 }

--- a/src/ModernApplicationFramework.Extended/ExtendedBootstrapper.cs
+++ b/src/ModernApplicationFramework.Extended/ExtendedBootstrapper.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
-using System.Linq;
-using System.Reflection;
 using System.Windows;
 using Caliburn.Micro;
 using ModernApplicationFramework.Basics.Services;
@@ -13,13 +11,11 @@ using ModernApplicationFramework.Utilities.Interfaces;
 
 namespace ModernApplicationFramework.Extended
 {
-    public class ExtendedBootstrapper : Bootstrapper
+    public abstract class ExtendedBootstrapper : Bootstrapper
     {
         protected virtual bool UseSettingsManager => true;
 
         protected new virtual IExtendedEnvironmentVariables EnvironmentVariables => new FallbackExtendedEnvironmentVariables();
-
-        internal IList<Assembly> PriorityAssemblies => _priorityAssemblies;
 
         protected override void BindServices(CompositionBatch batch)
         {
@@ -28,18 +24,7 @@ namespace ModernApplicationFramework.Extended
             base.BindServices(batch);
             batch.AddExportedValue(this);
         }
-
-        protected override object GetInstance(Type serviceType, string key)
-        {
-            var contract = string.IsNullOrEmpty(key) ? AttributedModelServices.GetContractName(serviceType) : key;
-            var exports = Container.GetExportedValues<object>(contract);
-
-            var enumerable = exports as object[] ?? exports.ToArray();
-            if (enumerable.Any())
-                return enumerable.First();
-            return null;
-        }
-
+        
         protected override void OnStartup(object sender, StartupEventArgs e)
         {
             base.OnStartup(sender, e);
@@ -53,14 +38,6 @@ namespace ModernApplicationFramework.Extended
         {
             IoC.Get<IApplicationEnvironment>().PrepareClose();
             base.OnExit(sender, e);
-        }
-
-        protected override IEnumerable<Assembly> SelectAssemblies()
-        {
-            return new[]
-            {
-                Assembly.GetEntryAssembly()
-            };
         }
     }
 }


### PR DESCRIPTION
1. Used bootstrappers in Caliburn.Micro way.
2. Removed `SelectAssemblies` method from `ExtendedBootstrapper`.
**Justification:** there's no more need in this, because we use abstract bootstrappers and `BaseBootstrapper` does the work for us (it uses `GetType()` which means it have assembly of most derived class).
3. Corrected accessibility levels in bootstrappers code.
4. Removed usage of `PrepareApplication` method.
**Justification:** `PrepareApplication` method isn't a proper place to cleanup folders. It must be used to prepare application events aka `OnStartup`, `OnExit`, e.t.c.
5. Removed reduntant cast to object array.
**Justification:** in any execution case it will never be called.
6. Removed redundant container and batch registration.